### PR TITLE
importing docs package to swagger init file

### DIFF
--- a/config/swagger.go
+++ b/config/swagger.go
@@ -3,6 +3,8 @@ package config
 import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/swagger"
+
+	_ "github.com/bmdavis419/the-better-backend/docs"
 )
 
 func AddSwaggerRoutes(app *fiber.App) {


### PR DESCRIPTION
The docs which are autogenerated by running cli commands need to be imported to the Swagger Route init file